### PR TITLE
Add profile memory with a button to manually add to memory; integrate with GPT call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,6 +1881,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5646,13 +5655,17 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
-      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/content-script/openai.js
+++ b/src/content-script/openai.js
@@ -1,6 +1,22 @@
-const OPENAI_API_KEY = "write_your_openai_api_key_here";
+import { PROFILE_MEMORY_KEY, OPENAI_API_KEY } from "../utils/constants";
 
 export async function callGPT4(messages) {
+  let profileData;
+  try {
+    profileData = await new Promise((resolve, reject) => {
+      chrome.storage.local.get(PROFILE_MEMORY_KEY, function(result) {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve(result[PROFILE_MEMORY_KEY] || ""); // Default to empty string if not found
+        }
+      });
+    });
+  }
+  catch (error) {
+    console.error("Error retrieving profile data:", error);
+    profileData = "";
+  }
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -14,7 +30,7 @@ export async function callGPT4(messages) {
           {
             role: 'system',
             content: 'You are a helpful assistant responding to LinkedIn messages on behalf of a the person receiving a certain LinkedIn message.'
-                + 'Answer any messages concisely, politely, and in a friendly tone.'
+                + `Answer any messages concisely, politely, and in a friendly tone. Use this profile data to help formulate your answers: ${profileData}`
           },
           {
             role: 'user',

--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -60,19 +60,8 @@ function App() {
       try {
         await chrome.storage.local.set({ [PROFILE_MEMORY_KEY]: profileData });
         console.log("Profile data saved successfully");
-        try {
-          chrome.storage.local.get(PROFILE_MEMORY_KEY, (result) => {
-            if (result[PROFILE_MEMORY_KEY]) {
-              console.log("Profile data retrieved successfully:", result[PROFILE_MEMORY_KEY]);
-            }
-          });
-        } catch (error) {
-          console.error("Error retrieving profile data:", error);
-          setAiResponse(`Error retrieving profile data: ${error.message}`);
-        }
       } catch (error) {
         console.error("Error saving profile data:", error);
-        setAiResponse(`Error saving profile data: ${error.message}`);
       }
     };
 
@@ -89,7 +78,6 @@ function App() {
         chrome.storage.local.get(PROFILE_MEMORY_KEY, (result) => {
           if (chrome.runtime.lastError) {
             console.error("Error retrieving profile data:", chrome.runtime.lastError);
-            setAiResponse(`Error retrieving profile data: ${chrome.runtime.lastError.message}`);
             return;
           }
           if (result[PROFILE_MEMORY_KEY]) {
@@ -101,7 +89,6 @@ function App() {
         });
       } catch (error) {
         console.error("Error retrieving profile data:", error);
-        setAiResponse(`Error retrieving profile data: ${error.message}`);
       }
     }
     fetchProfileData();

--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { callGPT4 } from "../content-script/openai";
+import { PROFILE_MEMORY_KEY } from "../utils/constants";
 
 function App() {
   const [messages, setMessages] = useState([]);
   const [aiResponse, setAiResponse] = useState("");
   const [started, setStarted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [saveProfile, setSaveProfile] = useState(false);
+  const [profileData, setProfileData] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalInput, setModalInput] = useState("");
 
   useEffect(() => {
     if (!started) return;
@@ -47,15 +52,83 @@ function App() {
     return () => clearInterval(interval);
   }, [started]);
 
+  useEffect(() => {
+    if (!saveProfile) return;
+
+    console.log("Save profile effect called");
+    const saveProfileToStorage = async () => {
+      try {
+        await chrome.storage.local.set({ [PROFILE_MEMORY_KEY]: profileData });
+        console.log("Profile data saved successfully");
+        try {
+          chrome.storage.local.get(PROFILE_MEMORY_KEY, (result) => {
+            if (result[PROFILE_MEMORY_KEY]) {
+              console.log("Profile data retrieved successfully:", result[PROFILE_MEMORY_KEY]);
+            }
+          });
+        } catch (error) {
+          console.error("Error retrieving profile data:", error);
+          setAiResponse(`Error retrieving profile data: ${error.message}`);
+        }
+      } catch (error) {
+        console.error("Error saving profile data:", error);
+        setAiResponse(`Error saving profile data: ${error.message}`);
+      }
+    };
+
+    saveProfileToStorage();
+    setSaveProfile(false);
+  }, [saveProfile, profileData]);
+
+  const handleUpdateProfile = () => {
+    console.log("Update profile handler called");
+    const fetchProfileData = () => {
+      try {
+        setModalInput("")
+        console.log("Fetching profile data to pre-fill modal input");
+        chrome.storage.local.get(PROFILE_MEMORY_KEY, (result) => {
+          if (chrome.runtime.lastError) {
+            console.error("Error retrieving profile data:", chrome.runtime.lastError);
+            setAiResponse(`Error retrieving profile data: ${chrome.runtime.lastError.message}`);
+            return;
+          }
+          if (result[PROFILE_MEMORY_KEY]) {
+            console.log("Profile data retrieved successfully:", result[PROFILE_MEMORY_KEY], "Setting modal input.");
+            setModalInput(result[PROFILE_MEMORY_KEY]);
+          } else {
+            console.log("No profile data found.", result);
+          }
+        });
+      } catch (error) {
+        console.error("Error retrieving profile data:", error);
+        setAiResponse(`Error retrieving profile data: ${error.message}`);
+      }
+    }
+    fetchProfileData();
+    setIsModalOpen(true);
+  };
+
+  const handleModalSubmit = () => {
+    setProfileData(modalInput);
+    setSaveProfile(true);
+    setIsModalOpen(false);
+  };
+
   return (
-      <div style={{ width: "300px", padding: "10px" }}>
+      <div style={{width: "300px", padding: "10px"}}>
         <h2>TARS (LinkedIn candidate screening chat bot)</h2>
         <button
             onClick={() => setStarted(true)}
             disabled={loading}
-            style={{ marginBottom: "10px" }}
+            style={{marginBottom: "10px"}}
         >
           {loading ? 'Processing...' : 'Start bot'}
+        </button>
+        <button
+          onClick={handleUpdateProfile}
+          style={{marginBottom: "10px", marginLeft: "10px"}}
+        >
+          Update profile
         </button>
         <div
             style={{
@@ -68,8 +141,44 @@ function App() {
         >
           {aiResponse}
         </div>
-      </div>
-  );
+
+        {isModalOpen && (
+          <div style={{
+            position: "fixed",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            backgroundColor: "white",
+            padding: "20px",
+            boxShadow: "0 0 10px rgba(0,0,0,0.1)",
+            zIndex: 1000
+          }}>
+            <h3>Update Profile</h3>
+            <textarea
+              value={modalInput}
+              onChange={(e) => setModalInput(e.target.value)}
+              style={{width: "100%", height: "100px"}}
+            />
+            <button onClick={handleModalSubmit} style={{marginTop: "10px"}}>
+              Save
+            </button>
+            <button onClick={() => setIsModalOpen(false)} style={{marginTop: "10px", marginLeft: "10px"}}>
+              Cancel
+            </button>
+          </div>
+        )}
+        {isModalOpen && (
+          <div style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            backgroundColor: "rgba(0,0,0,0.5)",
+            zIndex: 999
+          }} onClick={() => setIsModalOpen(false)} />
+        )}
+      </div>);
 }
 
 export default App;

--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -114,71 +114,68 @@ function App() {
     setIsModalOpen(false);
   };
 
-  return (
-      <div style={{width: "300px", padding: "10px"}}>
-        <h2>TARS (LinkedIn candidate screening chat bot)</h2>
-        <button
-            onClick={() => setStarted(true)}
-            disabled={loading}
-            style={{marginBottom: "10px"}}
-        >
-          {loading ? 'Processing...' : 'Start bot'}
-        </button>
-        <button
-          onClick={handleUpdateProfile}
-          style={{marginBottom: "10px", marginLeft: "10px"}}
-        >
-          Update profile
-        </button>
-        <div
-            style={{
-              marginTop: "10px",
-              padding: "10px",
-              backgroundColor: "#e6ffe6",
-              borderRadius: "5px",
-              whiteSpace: "pre-wrap"
-            }}
-        >
-          {aiResponse}
-        </div>
+  return (<div style={{width: "300px", padding: "10px"}}>
+    <h2>TARS (LinkedIn candidate screening chat bot)</h2>
+    <button
+        onClick={() => setStarted(true)}
+        disabled={loading}
+        style={{marginBottom: "10px"}}
+    >
+      {loading ? 'Processing...' : 'Start bot'}
+    </button>
+    <button
+        onClick={handleUpdateProfile}
+        style={{marginBottom: "10px", marginLeft: "10px"}}
+    >
+      Add/Update profile
+    </button>
+    <button
+        onClick={() => setStarted(false)}
+        style={{marginBottom: "10px", marginLeft: "10px"}}
+    >
+      Stop bot
+    </button>
+    <div
+        style={{
+          marginTop: "10px", padding: "10px", backgroundColor: "#e6ffe6", borderRadius: "5px", whiteSpace: "pre-wrap"
+        }}
+    >
+      {aiResponse}
+    </div>
 
-        {isModalOpen && (
-          <div style={{
-            position: "fixed",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            backgroundColor: "white",
-            padding: "20px",
-            boxShadow: "0 0 10px rgba(0,0,0,0.1)",
-            zIndex: 1000
-          }}>
-            <h3>Update Profile</h3>
-            <textarea
+    {isModalOpen && (<div style={{
+          position: "fixed",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          backgroundColor: "white",
+          padding: "20px",
+          boxShadow: "0 0 10px rgba(0,0,0,0.1)",
+          zIndex: 1000
+        }}>
+          <h3>Update Profile</h3>
+          <textarea
               value={modalInput}
               onChange={(e) => setModalInput(e.target.value)}
               style={{width: "100%", height: "100px"}}
-            />
-            <button onClick={handleModalSubmit} style={{marginTop: "10px"}}>
-              Save
-            </button>
-            <button onClick={() => setIsModalOpen(false)} style={{marginTop: "10px", marginLeft: "10px"}}>
-              Cancel
-            </button>
-          </div>
-        )}
-        {isModalOpen && (
-          <div style={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-            backgroundColor: "rgba(0,0,0,0.5)",
-            zIndex: 999
-          }} onClick={() => setIsModalOpen(false)} />
-        )}
-      </div>);
+          />
+          <button onClick={handleModalSubmit} style={{marginTop: "10px"}}>
+            Save
+          </button>
+          <button onClick={() => setIsModalOpen(false)} style={{marginTop: "10px", marginLeft: "10px"}}>
+            Cancel
+          </button>
+        </div>)}
+    {isModalOpen && (<div style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          backgroundColor: "rgba(0,0,0,0.5)",
+          zIndex: 999
+        }} onClick={() => setIsModalOpen(false)}/>)}
+  </div>);
 }
 
 export default App;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const PROFILE_MEMORY_KEY = "tars_profile_memory";

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,1 +1,2 @@
 export const PROFILE_MEMORY_KEY = "tars_profile_memory";
+export const OPENAI_API_KEY = "Enter your OpenAI API key here";


### PR DESCRIPTION
## List of changes
1. Created a button for adding/updating profile memory, and a button to stop the bot (since otherwise it keeps getting responses from GPT and overwriting previous responses)

2. Clicking on the button opens a modal where a user can write whatever they want to store as info about them. 
<img width="167" alt="image" src="https://github.com/user-attachments/assets/00c10538-45ea-44e4-9d75-89d7fa03ba19" />

This is committed to memory using `chrome.storage.local` and can be retrieved later. Whenever the user clicks on the "Update profile" button, the modal opens with the previously stored data.

3. Started the bot and this is the message I get from gpt:
<img width="316" alt="image" src="https://github.com/user-attachments/assets/25bd9443-8b7a-4281-af0f-cb8d8babb5e8" />

## Callouts
1. I didn't try to make the modal bigger than the window of our extension, or as a separate popup.